### PR TITLE
Replace deprecated sign-in redirectUrl

### DIFF
--- a/src/airclerk/main.py
+++ b/src/airclerk/main.py
@@ -208,7 +208,10 @@ async def login(request: air.Request, next: str = "/"):
 
                     window.Clerk.mountSignIn(
                         document.getElementById('sign-in'),
-                        {{ redirectUrl: '{next}' }}
+                        // Clerk JS 5.x deprecates redirectUrl for sign-in components.
+                        // next is an explicit, sanitized destination, so force it.
+                        // https://clerk.com/docs/guides/development/customize-redirect-urls
+                        {{ forceRedirectUrl: '{next}' }}
                     );
                     }})
                     """),

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,8 @@
-from airclerk.main import sanitize_next
+from unittest.mock import patch
+
+import air
+from airclerk.main import router, sanitize_next
+from starlette.testclient import TestClient
 
 
 def test_check():
@@ -53,3 +57,46 @@ class TestSanitizeNext:
     def test_case_insensitive_protocol_check(self):
         assert sanitize_next("HTTPS://example.com") == "/"
         assert sanitize_next("JavaScript:alert(1)") == "/"
+
+
+class _UnauthenticatedState:
+    is_signed_in = False
+
+
+class _FakeClerk:
+    def __init__(self, **kwargs):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+    def authenticate_request(self, *args, **kwargs):
+        return _UnauthenticatedState()
+
+
+def test_login_uses_force_redirect_url_for_explicit_next():
+    app = air.Air()
+    app.include_router(router)
+
+    with patch("airclerk.main.Clerk", _FakeClerk):
+        with TestClient(app) as client:
+            response = client.get("/login?next=/protected")
+
+    assert response.status_code == 200
+    assert "forceRedirectUrl: '/protected'" in response.text
+    assert "{ redirectUrl:" not in response.text
+
+
+def test_logout_keeps_redirect_url_for_sign_out():
+    app = air.Air()
+    app.include_router(router)
+
+    with TestClient(app) as client:
+        response = client.post("/logout")
+
+    assert response.status_code == 200
+    assert "signOut({ redirectUrl: '/' })" in response.text
+    assert "forceRedirectUrl" not in response.text


### PR DESCRIPTION
Fixes #4

- Use `forceRedirectUrl` for Clerk sign-in.
- Keep `redirectUrl` for sign-out.
- Add regression tests.

Tested with the public DOF-RAG human-evaluation Air app:
https://github.com/CodeandoGuadalajara/dof-rag/tree/main/human_eval

Checks: `pytest -q` (18 passed) and `ruff check src tests`.