### PR TITLE
Avoid fetching Clerk users for claims-only auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,4 +31,17 @@ app.add_middleware(air.SessionMiddleware, secret_key="change-me")
 app.include_router(airclerk.router)
 ```
 
+Use the verified session claims for most routes:
+
+```python
+@app.page
+def protected(claims=airclerk.require_auth_claims):
+    return air.P(f"Signed in as {claims['sub']}")
+```
+
+Use `airclerk.require_user` when a route needs the full Clerk profile. The
+existing `airclerk.require_auth` dependency remains an alias for that
+full-profile behavior. `airclerk.fetch_user(user_id)` is available for
+explicit lookups.
+
 When you run a development OAuth-powered Air application with AirClerk, don't use localhost as your domain, as Clerk does not support it. Use `127.0.0.1` instead.

--- a/README.md
+++ b/README.md
@@ -31,17 +31,47 @@ app.add_middleware(air.SessionMiddleware, secret_key="change-me")
 app.include_router(airclerk.router)
 ```
 
-Use the verified session claims for most routes:
+When you run a development OAuth-powered Air application with AirClerk, don't use localhost as your domain, as Clerk does not support it. Use `127.0.0.1` instead.
+
+### Reading user data from session claims
+
+For most routes, use the verified session claims. This avoids a request to
+Clerk's Backend API:
 
 ```python
 @app.page
 def protected(claims=airclerk.require_auth_claims):
-    return air.P(f"Signed in as {claims['sub']}")
+    user_id = claims["sub"]
+    organization_id = claims.get("org_id")
+    return air.P(f"Signed in as {user_id} ({organization_id or 'no organization'})")
 ```
 
-Use `airclerk.require_user` when a route needs the full Clerk profile. The
-existing `airclerk.require_auth` dependency remains an alias for that
-full-profile behavior. `airclerk.fetch_user(user_id)` is available for
-explicit lookups.
+The claims commonly include values such as `sub` (user ID), `sid` (session
+ID), and token timestamps. When a user has an active organization, organization
+claims may also be present. The exact set depends on your Clerk session token
+version and configuration. See Clerk's [session token claims
+reference](https://clerk.com/docs/guides/sessions/session-tokens) for the
+default claims and [custom session token
+guide](https://clerk.com/docs/guides/sessions/customize-session-tokens) for
+adding your own.
 
-When you run a development OAuth-powered Air application with AirClerk, don't use localhost as your domain, as Clerk does not support it. Use `127.0.0.1` instead.
+To see what your instance provides, temporarily log the claims on the server:
+
+```python
+@app.page
+def inspect_claims(claims=airclerk.require_auth_claims):
+    print(sorted(claims))
+    return air.P("Claims were printed to the server log.")
+```
+
+Do not expose claims or session tokens in a public response or log in
+production.
+
+If a route needs fields that are not in the claims, use the full Clerk user
+profile dependency:
+
+```python
+@app.page
+def profile(user=airclerk.require_user):
+    return air.P(user.first_name or user.id)
+```

--- a/src/airclerk/__init__.py
+++ b/src/airclerk/__init__.py
@@ -1,4 +1,8 @@
 from .main import require_auth as require_auth
+from .main import require_auth_claims as require_auth_claims
+from .main import require_user as require_user
+from .main import fetch_user as fetch_user
+from .main import optional_auth_claims as optional_auth_claims
 from .main import optional_user as optional_user
 from .main import clerk_scripts as clerk_scripts
 from .main import router as router

--- a/src/airclerk/main.py
+++ b/src/airclerk/main.py
@@ -3,7 +3,7 @@ from urllib.parse import urlparse
 
 import air
 from clerk_backend_api import Clerk
-from clerk_backend_api.security.types import AuthenticateRequestOptions
+from clerk_backend_api.security.types import AuthenticateRequestOptions, RequestState
 from fastapi import Depends, status
 import httpx
 from pydantic_settings import BaseSettings
@@ -64,60 +64,82 @@ async def _to_httpx_request(request: air.Request) -> httpx.Request:
     )
 
 
-async def _authenticate_request(
-    request: air.Request,
-) -> tuple[Any, Dict[str, Any] | None]:
-    """Shared authentication logic - returns (state, user) tuple."""
+async def _authenticate_request(request: air.Request) -> RequestState:
+    """Authenticate a request and return Clerk's verified request state."""
     httpx_request = await _to_httpx_request(request)
     origin = f"{request.url.scheme}://{request.url.netloc}"
 
     with Clerk(bearer_auth=settings.CLERK_SECRET_KEY) as clerk:
-        state = clerk.authenticate_request(
+        return clerk.authenticate_request(
             httpx_request,
             AuthenticateRequestOptions(authorized_parties=[origin]),
         )
 
-        if not state.is_signed_in:
-            return state, None
 
-        user_id = getattr(state, "user_id", None) or state.payload.get("sub")
-        user = clerk.users.get(user_id=user_id)
-        return state, user
+def _login_redirect(request: air.Request) -> None:
+    redirect_after_login = str(request.url.path)
+    if request.url.query:
+        redirect_after_login += f"?{request.url.query}"
 
-
-async def _require_auth(request: air.Request) -> Dict[str, Any]:
-    """Require user to be authenticated - raises exception that redirects if not."""
-    _, user = await _authenticate_request(request)
-
-    if user is None:
-        redirect_after_login = str(request.url.path)
-        if request.url.query:
-            redirect_after_login += f"?{request.url.query}"
-
-        redirect_after_login = sanitize_next(redirect_after_login)
-        login_url = f"{login.url()}?next={redirect_after_login}"
-
-        if request.htmx:
-            raise air.HTTPException(
-                status_code=status.HTTP_303_SEE_OTHER,
-                headers={"Location": login_url},
-            )
-        raise air.HTTPException(
-            status_code=status.HTTP_303_SEE_OTHER,
-            headers={"Location": login_url},
-        )
-
-    return user
+    redirect_after_login = sanitize_next(redirect_after_login)
+    login_url = f"{login.url()}?next={redirect_after_login}"
+    raise air.HTTPException(
+        status_code=status.HTTP_303_SEE_OTHER,
+        headers={"Location": login_url},
+    )
 
 
-async def _optional_auth(request: air.Request) -> Dict[str, Any] | None:
-    """Authenticate user if possible, return None if not authenticated (no redirect)."""
-    _, user = await _authenticate_request(request)
-    return user
+async def _require_auth_claims(request: air.Request) -> Dict[str, Any]:
+    """Require authentication and return the verified JWT claims."""
+    state = await _authenticate_request(request)
+    if not state.is_signed_in:
+        _login_redirect(request)
+    return state.payload or {}
 
 
-require_auth = Depends(_require_auth)
-optional_user = Depends(_optional_auth)
+async def _optional_auth_claims(request: air.Request) -> Dict[str, Any] | None:
+    """Return verified JWT claims when the request is authenticated."""
+    state = await _authenticate_request(request)
+    if not state.is_signed_in:
+        return None
+    return state.payload or {}
+
+
+def fetch_user(user_id: str) -> Any:
+    """Fetch a full Clerk user profile by ID when profile fields are needed."""
+    with Clerk(bearer_auth=settings.CLERK_SECRET_KEY) as clerk:
+        return clerk.users.get(user_id=user_id)
+
+
+async def _require_user(request: air.Request) -> Any:
+    """Require authentication and fetch the full Clerk user profile."""
+    claims = await _require_auth_claims(request)
+    user_id = claims.get("sub")
+    if not user_id:
+        raise air.HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+    return fetch_user(user_id)
+
+
+async def _optional_user(request: air.Request) -> Any | None:
+    """Fetch the full Clerk user profile when the request is authenticated."""
+    claims = await _optional_auth_claims(request)
+    if claims is None:
+        return None
+    user_id = claims.get("sub")
+    if not user_id:
+        return None
+    return fetch_user(user_id)
+
+
+require_auth_claims = Depends(_require_auth_claims)
+optional_auth_claims = Depends(_optional_auth_claims)
+require_user = Depends(_require_user)
+optional_user = Depends(_optional_user)
+
+# Keep the existing name as a compatibility alias for applications that need
+# the full user object. New routes should choose require_auth_claims unless
+# they need profile fields.
+require_auth = require_user
 
 
 def clerk_scripts(user: Dict[str, Any] | None = None) -> air.Tag:

--- a/src/airclerk/main.py
+++ b/src/airclerk/main.py
@@ -114,7 +114,7 @@ def fetch_user(user_id: str) -> Any:
         return clerk.users.get(user_id=user_id)
 
 
-async def _require_user(
+def _require_user(
     claims: Dict[str, Any] = Depends(_require_auth_claims),
 ) -> Any:
     """Require authentication and fetch the full Clerk user profile."""
@@ -124,7 +124,7 @@ async def _require_user(
     return fetch_user(user_id)
 
 
-async def _optional_user(
+def _optional_user(
     claims: Dict[str, Any] | None = Depends(_optional_auth_claims),
 ) -> Any | None:
     """Fetch the full Clerk user profile when the request is authenticated."""

--- a/src/airclerk/main.py
+++ b/src/airclerk/main.py
@@ -72,7 +72,10 @@ async def _authenticate_request(request: air.Request) -> RequestState:
     with Clerk(bearer_auth=settings.CLERK_SECRET_KEY) as clerk:
         return clerk.authenticate_request(
             httpx_request,
-            AuthenticateRequestOptions(authorized_parties=[origin]),
+            AuthenticateRequestOptions(
+                authorized_parties=[origin],
+                accepts_token=["session_token"],
+            ),
         )
 
 
@@ -111,18 +114,20 @@ def fetch_user(user_id: str) -> Any:
         return clerk.users.get(user_id=user_id)
 
 
-async def _require_user(request: air.Request) -> Any:
+async def _require_user(
+    claims: Dict[str, Any] = Depends(_require_auth_claims),
+) -> Any:
     """Require authentication and fetch the full Clerk user profile."""
-    claims = await _require_auth_claims(request)
     user_id = claims.get("sub")
     if not user_id:
         raise air.HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
     return fetch_user(user_id)
 
 
-async def _optional_user(request: air.Request) -> Any | None:
+async def _optional_user(
+    claims: Dict[str, Any] | None = Depends(_optional_auth_claims),
+) -> Any | None:
     """Fetch the full Clerk user profile when the request is authenticated."""
-    claims = await _optional_auth_claims(request)
     if claims is None:
         return None
     user_id = claims.get("sub")

--- a/src/airclerk/main.py
+++ b/src/airclerk/main.py
@@ -150,20 +150,20 @@ require_auth = require_user
 def clerk_scripts(user: Dict[str, Any] | None = None) -> air.Tag:
     """Return Clerk JS script tags with auto-reload on auth state mismatch.
 
-    Include this on pages using optional_user to ensure server/client auth state stays in sync.
+    Include this on pages using optional_auth_claims to ensure server/client auth state stays in sync.
     After login, if the server hasn't seen the session cookie yet, this auto-reloads the page.
 
     Args:
-        user: The user object from optional_user. Pass it to enable auto-sync.
+        user: Server-side authentication state or verified session claims. Pass it to enable auto-sync.
 
     Returns:
         Script tags to include in your page.
 
     Example:
         @app.page
-        def index(user=airclerk.optional_user):
+        def index(claims=airclerk.optional_auth_claims):
             return air.Tag(
-                airclerk.clerk_scripts(user),
+                airclerk.clerk_scripts(claims),
                 air.H1("Welcome"),
                 # ... rest of page
             )

--- a/src/airclerk/main.py
+++ b/src/airclerk/main.py
@@ -1,5 +1,5 @@
 from typing import Any, Dict
-from urllib.parse import urlparse
+from urllib.parse import urlencode, urlparse
 
 import air
 from clerk_backend_api import Clerk
@@ -82,7 +82,7 @@ def _login_redirect(request: air.Request) -> None:
         redirect_after_login += f"?{request.url.query}"
 
     redirect_after_login = sanitize_next(redirect_after_login)
-    login_url = f"{login.url()}?next={redirect_after_login}"
+    login_url = f"{login.url()}?{urlencode({'next': redirect_after_login})}"
     raise air.HTTPException(
         status_code=status.HTTP_303_SEE_OTHER,
         headers={"Location": login_url},

--- a/tests/demo.py
+++ b/tests/demo.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 import air
 import airclerk
 
@@ -20,12 +18,10 @@ def dump(obj: dict) -> air.BaseTag:
 
 
 @app.page
-def index(request: air.Request, user=airclerk.optional_user):
+def index(request: air.Request, claims=airclerk.optional_auth_claims):
     links = []
-    if user:
-        email = (
-            user.email_addresses[0].email_address if user.email_addresses else user.id
-        )
+    if claims:
+        email = claims.get("email") or claims.get("sub")
         links.extend(
             [
                 air.Li(f"Logged in as {email}"),
@@ -42,7 +38,7 @@ def index(request: air.Request, user=airclerk.optional_user):
         )
 
     return air.Tag(
-        airclerk.clerk_scripts(user),
+        airclerk.clerk_scripts(claims),
         air.layouts.mvpcss(
             air.H1("AirClerk demo"),
             air.Ul(*links),
@@ -52,15 +48,11 @@ def index(request: air.Request, user=airclerk.optional_user):
 
 
 @app.page
-def protected(request: air.Request, user=airclerk.require_auth):
+def protected(request: air.Request, claims=airclerk.require_auth_claims):
     return air.layouts.mvpcss(
-        airclerk.clerk_scripts(user),
+        airclerk.clerk_scripts(claims),
         air.H1("Protected view"),
         air.P(air.A("home", href=index.url())),
-        air.H2("Clerk user object"),
-        air.P(
-            air.Strong("Last sign in at: "),
-            datetime.fromtimestamp(user.last_sign_in_at / 1000),
-        ),
-        dump(user),
+        air.H2("Clerk session claims"),
+        dump(claims),
     )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,5 @@
 from unittest.mock import patch
+from urllib.parse import parse_qs, urlparse
 
 import air
 import airclerk
@@ -114,10 +115,11 @@ def test_claims_dependency_redirects_unauthenticated_requests():
 
     with patch("airclerk.main.Clerk", _UnauthenticatedFakeClerk):
         with TestClient(app) as client:
-            response = client.get("/protected", follow_redirects=False)
+            response = client.get("/protected?a=1&b=2", follow_redirects=False)
 
     assert response.status_code == 303
-    assert response.headers["location"] == "/login?next=/protected"
+    location = response.headers["location"]
+    assert parse_qs(urlparse(location).query)["next"] == ["/protected?a=1&b=2"]
 
 
 def test_claims_dependency_does_not_fetch_full_user():
@@ -151,5 +153,47 @@ def test_full_user_dependency_fetches_profile_on_request():
 
     assert response.status_code == 200
     assert "Full profile" in response.text
+    calls = [user_id for clerk in _FakeClerk.instances for user_id in clerk.users.calls]
+    assert calls == ["user_123"]
+
+
+def test_optional_claims_dependency_returns_none_without_authentication():
+    app = air.Air()
+
+    @app.page
+    def optional(claims=airclerk.optional_auth_claims):
+        return air.P("signed out" if claims is None else "signed in")
+
+    with patch("airclerk.main.Clerk", _UnauthenticatedFakeClerk):
+        with TestClient(app) as client:
+            response = client.get("/optional")
+
+    assert response.status_code == 200
+    assert "signed out" in response.text
+
+
+def test_optional_dependencies_fetch_only_when_full_user_is_requested():
+    _FakeClerk.instances.clear()
+    app = air.Air()
+
+    @app.page
+    def claims(claims=airclerk.optional_auth_claims):
+        return air.P(claims["sub"])
+
+    @app.page
+    def user(user=airclerk.optional_user):
+        return air.P(user.name)
+
+    with patch("airclerk.main.Clerk", _FakeClerk):
+        with TestClient(app) as client:
+            claims_response = client.get(
+                "/claims", headers={"cookie": "__session=token"}
+            )
+            user_response = client.get("/user", headers={"cookie": "__session=token"})
+
+    assert claims_response.status_code == 200
+    assert "user_123" in claims_response.text
+    assert user_response.status_code == 200
+    assert "Full profile" in user_response.text
     calls = [user_id for clerk in _FakeClerk.instances for user_id in clerk.users.calls]
     assert calls == ["user_123"]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -89,6 +89,8 @@ class _FakeClerk:
 
     def __init__(self, **kwargs):
         self.users = _FakeUsers()
+        self.auth_calls = 0
+        self.auth_options = []
         self.instances.append(self)
 
     def __enter__(self):
@@ -98,6 +100,8 @@ class _FakeClerk:
         pass
 
     def authenticate_request(self, *args, **kwargs):
+        self.auth_calls += 1
+        self.auth_options.append(args[1])
         return _AuthenticatedState()
 
 
@@ -137,6 +141,11 @@ def test_claims_dependency_does_not_fetch_full_user():
     assert response.status_code == 200
     assert "user_123" in response.text
     assert all(not clerk.users.calls for clerk in _FakeClerk.instances)
+    assert all(
+        option.accepts_token == ["session_token"]
+        for clerk in _FakeClerk.instances
+        for option in clerk.auth_options
+    )
 
 
 def test_full_user_dependency_fetches_profile_on_request():
@@ -197,3 +206,42 @@ def test_optional_dependencies_fetch_only_when_full_user_is_requested():
     assert "Full profile" in user_response.text
     calls = [user_id for clerk in _FakeClerk.instances for user_id in clerk.users.calls]
     assert calls == ["user_123"]
+
+
+def test_required_dependencies_reuse_authentication():
+    _FakeClerk.instances.clear()
+    app = air.Air()
+
+    @app.page
+    def profile(claims=airclerk.require_auth_claims, user=airclerk.require_user):
+        return air.P(claims["sub"], user.name)
+
+    with patch("airclerk.main.Clerk", _FakeClerk):
+        with TestClient(app) as client:
+            response = client.get("/profile", headers={"cookie": "__session=token"})
+
+    assert response.status_code == 200
+    assert "user_123" in response.text
+    assert "Full profile" in response.text
+    assert sum(clerk.auth_calls for clerk in _FakeClerk.instances) == 1
+
+
+def test_optional_dependencies_reuse_authentication():
+    _FakeClerk.instances.clear()
+    app = air.Air()
+
+    @app.page
+    def profile(
+        claims=airclerk.optional_auth_claims,
+        user=airclerk.optional_user,
+    ):
+        return air.P(claims["sub"], user.name)
+
+    with patch("airclerk.main.Clerk", _FakeClerk):
+        with TestClient(app) as client:
+            response = client.get("/profile", headers={"cookie": "__session=token"})
+
+    assert response.status_code == 200
+    assert "user_123" in response.text
+    assert "Full profile" in response.text
+    assert sum(clerk.auth_calls for clerk in _FakeClerk.instances) == 1

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,9 @@
+from unittest.mock import patch
+
+import air
+import airclerk
 from airclerk.main import sanitize_next
+from starlette.testclient import TestClient
 
 
 def test_check():
@@ -53,3 +58,98 @@ class TestSanitizeNext:
     def test_case_insensitive_protocol_check(self):
         assert sanitize_next("HTTPS://example.com") == "/"
         assert sanitize_next("JavaScript:alert(1)") == "/"
+
+
+class _UnauthenticatedState:
+    is_signed_in = False
+
+
+class _AuthenticatedState:
+    is_signed_in = True
+    payload = {
+        "sub": "user_123",
+        "sid": "session_123",
+        "org_id": "org_123",
+        "org_role": "org:member",
+    }
+
+
+class _FakeUsers:
+    def __init__(self):
+        self.calls = []
+
+    def get(self, *, user_id):
+        self.calls.append(user_id)
+        return type("FakeUser", (), {"id": user_id, "name": "Full profile"})()
+
+
+class _FakeClerk:
+    instances = []
+
+    def __init__(self, **kwargs):
+        self.users = _FakeUsers()
+        self.instances.append(self)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+    def authenticate_request(self, *args, **kwargs):
+        return _AuthenticatedState()
+
+
+class _UnauthenticatedFakeClerk(_FakeClerk):
+    def authenticate_request(self, *args, **kwargs):
+        return _UnauthenticatedState()
+
+
+def test_claims_dependency_redirects_unauthenticated_requests():
+    app = air.Air()
+
+    @app.page
+    def protected(claims=airclerk.require_auth_claims):
+        return air.P(claims["sub"])
+
+    with patch("airclerk.main.Clerk", _UnauthenticatedFakeClerk):
+        with TestClient(app) as client:
+            response = client.get("/protected", follow_redirects=False)
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/login?next=/protected"
+
+
+def test_claims_dependency_does_not_fetch_full_user():
+    _FakeClerk.instances.clear()
+    app = air.Air()
+
+    @app.page
+    def protected(claims=airclerk.require_auth_claims):
+        return air.P(claims["sub"])
+
+    with patch("airclerk.main.Clerk", _FakeClerk):
+        with TestClient(app) as client:
+            response = client.get("/protected", headers={"cookie": "__session=token"})
+
+    assert response.status_code == 200
+    assert "user_123" in response.text
+    assert all(not clerk.users.calls for clerk in _FakeClerk.instances)
+
+
+def test_full_user_dependency_fetches_profile_on_request():
+    _FakeClerk.instances.clear()
+    app = air.Air()
+
+    @app.page
+    def protected(user=airclerk.require_user):
+        return air.P(user.name)
+
+    with patch("airclerk.main.Clerk", _FakeClerk):
+        with TestClient(app) as client:
+            response = client.get("/protected", headers={"cookie": "__session=token"})
+
+    assert response.status_code == 200
+    assert "Full profile" in response.text
+    calls = [user_id for clerk in _FakeClerk.instances for user_id in clerk.users.calls]
+    assert calls == ["user_123"]


### PR DESCRIPTION
Fixes #5

- Add claims-only dependencies for common auth checks.
- Keep full profile lookup explicit with `require_user`.
- Avoid duplicate authentication for composed dependencies.
- Restrict the verifier to session tokens.
- Update the demo, README, and tests.

Checks: 23 tests passed; Ruff and formatting passed.

Review history: [original fork PR #2](https://github.com/jackbravo/AirClerk/pull/2) contains the GitHub Copilot review rounds.