### PR TITLE
Replace deprecated sign-in redirectUrl

### DIFF
--- a/src/airclerk/main.py
+++ b/src/airclerk/main.py
@@ -208,7 +208,10 @@ async def login(request: air.Request, next: str = "/"):
 
                     window.Clerk.mountSignIn(
                         document.getElementById('sign-in'),
-                        {{ redirectUrl: '{next}' }}
+                        // Clerk JS 5.x deprecates redirectUrl for sign-in components.
+                        // next is an explicit, sanitized destination, so force it.
+                        // https://clerk.com/docs/guides/development/customize-redirect-urls
+                        {{ forceRedirectUrl: '{next}' }}
                     );
                     }})
                     """),

--- a/src/airclerk/main.py
+++ b/src/airclerk/main.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any, Dict
 from urllib.parse import urlparse
 
@@ -32,6 +33,16 @@ def sanitize_next(raw: str, default: str = "/") -> str:
         return default
 
     return raw
+
+
+def _js_string_literal(value: str) -> str:
+    """Serialize a value for safe insertion as a JavaScript string literal."""
+    return (
+        json.dumps(value, ensure_ascii=True)
+        .replace("<", r"\u003c")
+        .replace(">", r"\u003e")
+        .replace("&", r"\u0026")
+    )
 
 
 class Settings(BaseSettings):
@@ -176,6 +187,7 @@ async def login(request: air.Request, next: str = "/"):
     httpx_request = await _to_httpx_request(request)
     origin = f"{request.url.scheme}://{request.url.netloc}"
     next = sanitize_next(next)
+    next_js = _js_string_literal(next)
 
     with Clerk(bearer_auth=settings.CLERK_SECRET_KEY) as clerk:
         state = clerk.authenticate_request(
@@ -202,7 +214,7 @@ async def login(request: air.Request, next: str = "/"):
                     await window.Clerk.load();
 
                     if (window.Clerk.user) {{
-                        window.location.assign('{next}');
+                        window.location.assign({next_js});
                         return;
                     }}
 
@@ -211,7 +223,7 @@ async def login(request: air.Request, next: str = "/"):
                         // Clerk JS 5.x deprecates redirectUrl for sign-in components.
                         // next is an explicit, sanitized destination, so force it.
                         // https://clerk.com/docs/guides/development/customize-redirect-urls
-                        {{ forceRedirectUrl: '{next}' }}
+                        {{ forceRedirectUrl: {next_js} }}
                     );
                     }})
                     """),

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,8 @@
-from airclerk.main import sanitize_next
+from unittest.mock import patch
+
+import air
+from airclerk.main import router, sanitize_next
+from starlette.testclient import TestClient
 
 
 def test_check():
@@ -53,3 +57,46 @@ class TestSanitizeNext:
     def test_case_insensitive_protocol_check(self):
         assert sanitize_next("HTTPS://example.com") == "/"
         assert sanitize_next("JavaScript:alert(1)") == "/"
+
+
+class _UnauthenticatedState:
+    is_signed_in = False
+
+
+class _FakeClerk:
+    def __init__(self, **kwargs):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+    def authenticate_request(self, *args, **kwargs):
+        return _UnauthenticatedState()
+
+
+def test_login_uses_force_redirect_url_for_explicit_next():
+    app = air.Air()
+    app.include_router(router)
+
+    with patch("airclerk.main.Clerk", _FakeClerk):
+        with TestClient(app) as client:
+            response = client.get("/login?next=/protected")
+
+    assert response.status_code == 200
+    assert "forceRedirectUrl: '/protected'" in response.text
+    assert "{ redirectUrl:" not in response.text
+
+
+def test_logout_keeps_redirect_url_for_sign_out():
+    app = air.Air()
+    app.include_router(router)
+
+    with TestClient(app) as client:
+        response = client.post("/logout")
+
+    assert response.status_code == 200
+    assert "signOut({ redirectUrl: '/' })" in response.text
+    assert "forceRedirectUrl" not in response.text

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,7 @@
 from unittest.mock import patch
 
 import air
-from airclerk.main import router, sanitize_next
+from airclerk.main import _js_string_literal, router, sanitize_next
 from starlette.testclient import TestClient
 
 
@@ -86,8 +86,26 @@ def test_login_uses_force_redirect_url_for_explicit_next():
             response = client.get("/login?next=/protected")
 
     assert response.status_code == 200
-    assert "forceRedirectUrl: '/protected'" in response.text
+    assert 'forceRedirectUrl: "/protected"' in response.text
+    assert 'window.location.assign("/protected")' in response.text
     assert "{ redirectUrl:" not in response.text
+
+
+def test_login_escapes_next_before_embedding_in_script():
+    app = air.Air()
+    app.include_router(router)
+    dangerous_next = '/";alert(document.domain);//</script>&\\'
+    next_js = _js_string_literal(dangerous_next)
+
+    with patch("airclerk.main.Clerk", _FakeClerk):
+        with TestClient(app) as client:
+            response = client.get("/login", params={"next": dangerous_next})
+
+    assert response.status_code == 200
+    assert "</script>" not in next_js
+    assert r"\u003c/script\u003e\u0026" in next_js
+    assert f"window.location.assign({next_js})" in response.text
+    assert f"forceRedirectUrl: {next_js}" in response.text
 
 
 def test_logout_keeps_redirect_url_for_sign_out():


### PR DESCRIPTION
Fixes #4

- Use `forceRedirectUrl` for Clerk sign-in.
- Keep `redirectUrl` for sign-out.
- Add regression tests.
- Escape the request-controlled redirect before embedding it in scripts.

Reproduced in the public DOF-RAG human-evaluation Air app:
https://github.com/CodeandoGuadalajara/dof-rag/tree/main/human_eval

Checks: 19 tests passed; Ruff and formatting passed.

Review history: [original fork PR #1](https://github.com/jackbravo/AirClerk/pull/1) contains the GitHub Copilot review rounds.